### PR TITLE
[Adapters] Load adapters on server init 

### DIFF
--- a/benchmark/src/generation.rs
+++ b/benchmark/src/generation.rs
@@ -217,7 +217,5 @@ fn create_sequence(sequence_length: u32, tokenizer: Tokenizer) -> String {
     // Truncate to sequence_length
     encoding.truncate(sequence_length as usize, 0, TruncationDirection::Left);
     // Decode
-    tokenizer
-        .decode(Vec::from(encoding.get_ids()), false)
-        .unwrap()
+    tokenizer.decode(encoding.get_ids(), false).unwrap()
 }

--- a/router/src/validation.rs
+++ b/router/src/validation.rs
@@ -311,7 +311,7 @@ fn prepare_input(
             // truncate encoding and decode new inputs
             encoding.truncate(truncate, 0, TruncationDirection::Left);
             let inputs = tokenizer
-                .decode(Vec::from(encoding.get_ids()), false)
+                .decode(encoding.get_ids(), false)
                 .map_err(|err| ValidationError::Tokenizer(err.to_string()))?;
             (inputs, encoding.len())
         }

--- a/server/Makefile
+++ b/server/Makefile
@@ -24,7 +24,7 @@ install: gen-server install-torch
 	pip install -e ".[bnb, accelerate]"
 
 run-dev:
-	SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=2 text_generation_server/cli.py serve bigscience/bloom-560m --sharded
+	SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=1 text_generation_server/cli.py serve meta-llama/Llama-2-7b-hf --adapter-id arnavgrg/codealpaca-qlora --sharded
 
 export-requirements:
 	poetry export -o requirements.txt -E bnb -E quantize --without-hashes

--- a/server/tests/utils/test_adapter.py
+++ b/server/tests/utils/test_adapter.py
@@ -1,0 +1,44 @@
+import torch
+from peft import LoraConfig
+
+from text_generation_server.utils.adapter import merge_adapter_weights
+
+
+def test_merge_adapter_weights():
+    W_0 = torch.tensor([
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9]
+    ])
+    model_weights = {
+        "model.layers.10.self_attn.q_proj.weight": W_0
+    }
+    
+    A = torch.tensor([
+        [1, 2, 3],
+        [4, 5, 6]
+    ])
+    B = torch.tensor([
+        [1, 2],
+        [3, 4],
+        [5, 6]
+    ])
+    adapter_weights = {
+        "base_model.model.model.layers.10.self_attn.q_proj.lora_A.weight": A,
+        "base_model.model.model.layers.10.self_attn.q_proj.lora_B.weight": B
+    }
+
+    W_expected = torch.tensor([
+        [ 5.5000,  8.0000, 10.5000],
+        [13.5000, 18.0000, 22.5000],
+        [21.5000, 28.0000, 34.5000]
+    ])
+    adapter_config = LoraConfig(r=2, lora_alpha=1, fan_in_fan_out=False)
+    merged_weights, processed_adapter_weight_names = merge_adapter_weights(model_weights, adapter_weights, adapter_config)
+
+    assert len(merged_weights) == 1
+    assert merged_weights["model.layers.10.self_attn.q_proj.weight"].equal(W_expected)
+    
+    assert len(processed_adapter_weight_names) == 2
+    assert "base_model.model.model.layers.10.self_attn.q_proj.lora_A.weight" in processed_adapter_weight_names
+    assert "base_model.model.model.layers.10.self_attn.q_proj.lora_B.weight" in processed_adapter_weight_names

--- a/server/text_generation_server/cli.py
+++ b/server/text_generation_server/cli.py
@@ -24,6 +24,7 @@ class Dtype(str, Enum):
 @app.command()
 def serve(
     model_id: str,
+    adapter_id: str = "",
     revision: Optional[str] = None,
     sharded: bool = False,
     quantize: Optional[Quantization] = None,
@@ -76,7 +77,7 @@ def serve(
             "Only 1 can be set between `dtype` and `quantize`, as they both decide how goes the final model."
         )
     server.serve(
-        model_id, revision, sharded, quantize, dtype, trust_remote_code, uds_path
+        model_id, adapter_id, revision, sharded, quantize, dtype, trust_remote_code, uds_path
     )
 
 

--- a/server/text_generation_server/models/__init__.py
+++ b/server/text_generation_server/models/__init__.py
@@ -68,12 +68,19 @@ if FLASH_ATTENTION:
 
 def get_model(
     model_id: str,
+    adapter_id: str,
     revision: Optional[str],
     sharded: bool,
     quantize: Optional[str],
     dtype: Optional[str],
     trust_remote_code: bool,
 ) -> Model:
+    if len(adapter_id) > 0:
+        logger.warning(
+            "adapter_id is only supported for FlashLlama models and will be "
+            "ignored for other models."
+        )
+
     if dtype is None:
         dtype = torch.float16
     elif dtype == "float16":
@@ -184,6 +191,7 @@ def get_model(
         if FLASH_ATTENTION:
             return FlashLlama(
                 model_id,
+                adapter_id,
                 revision,
                 quantize=quantize,
                 dtype=dtype,

--- a/server/text_generation_server/models/flash_llama.py
+++ b/server/text_generation_server/models/flash_llama.py
@@ -23,11 +23,21 @@ class FlashLlama(FlashCausalLM):
     def __init__(
         self,
         model_id: str,
+        adapter_id: str,
         revision: Optional[str] = None,
         quantize: Optional[str] = None,
         dtype: Optional[torch.dtype] = None,
         trust_remote_code: bool = False,
     ):
+        print("ASDFASDF FLASHLLAMA INIT")
+        print("Args:")
+        print(f"model_id: {model_id}")
+        print(f"adapter_id: {adapter_id}")
+        print(f"revision: {revision}")
+        print(f"quantize: {quantize}")
+        print(f"dtype: {dtype}")
+        print(f"trust_remote_code: {trust_remote_code}")
+        
         self.process_group, rank, world_size = initialize_torch_distributed()
         if torch.cuda.is_available():
             device = torch.device(f"cuda:{rank}")

--- a/server/text_generation_server/server.py
+++ b/server/text_generation_server/server.py
@@ -106,6 +106,7 @@ class TextGenerationService(generate_pb2_grpc.TextGenerationServiceServicer):
 
 def serve(
     model_id: str,
+    adapter_id: str,
     revision: Optional[str],
     sharded: bool,
     quantize: Optional[str],
@@ -115,6 +116,7 @@ def serve(
 ):
     async def serve_inner(
         model_id: str,
+        adapter_id: str,
         revision: Optional[str],
         sharded: bool = False,
         quantize: Optional[str] = None,
@@ -134,7 +136,7 @@ def serve(
 
         try:
             model = get_model(
-                model_id, revision, sharded, quantize, dtype, trust_remote_code
+                model_id, adapter_id, revision, sharded, quantize, dtype, trust_remote_code
             )
         except Exception:
             logger.exception("Error when initializing model")
@@ -182,5 +184,5 @@ def serve(
             await server.stop(0)
 
     asyncio.run(
-        serve_inner(model_id, revision, sharded, quantize, dtype, trust_remote_code)
+        serve_inner(model_id, adapter_id, revision, sharded, quantize, dtype, trust_remote_code)
     )

--- a/server/text_generation_server/utils/__init__.py
+++ b/server/text_generation_server/utils/__init__.py
@@ -1,3 +1,4 @@
+from text_generation_server.utils.adapter import create_merged_weight_files
 from text_generation_server.utils.convert import convert_file, convert_files
 from text_generation_server.utils.dist import initialize_torch_distributed
 from text_generation_server.utils.weights import Weights
@@ -20,6 +21,7 @@ from text_generation_server.utils.tokens import (
 )
 
 __all__ = [
+    "create_merged_weight_files",
     "convert_file",
     "convert_files",
     "initialize_torch_distributed",

--- a/server/text_generation_server/utils/adapter.py
+++ b/server/text_generation_server/utils/adapter.py
@@ -1,0 +1,127 @@
+import os
+from collections import defaultdict
+from pathlib import Path
+from typing import List, Dict, Set, Tuple
+
+import torch
+from loguru import logger
+from peft import LoraConfig
+from peft.utils import transpose
+from safetensors.torch import load_file, save_file
+from tqdm import tqdm
+
+from text_generation_server.utils.hub import weight_files
+
+
+def compute_delta_weight(
+    lora_A: torch.Tensor, 
+    lora_B: torch.Tensor, 
+    fan_in_fan_out: bool, 
+    alpha: float, 
+    r: float
+) -> torch.Tensor:
+    """Computes the delta weight for a Linear layer given A and B LoRA matrices.
+    
+    TODO: add logic for other module types beyond Linear layers.
+    
+    Reference: https://github.com/huggingface/peft/blob/v0.4.0/src/peft/tuners/lora.py#L799-L806
+    """
+    scaling = alpha / r
+    delta_weight = transpose(lora_B @ lora_A, fan_in_fan_out) * scaling
+    return delta_weight
+
+
+def merge_adapter_weights(
+    model_weights: Dict[str, torch.Tensor], 
+    adapter_weights: Dict[str, torch.Tensor], 
+    adapter_config: LoraConfig
+) -> Tuple[Dict[str, torch.Tensor], Set[str]]:
+    """Merges the adapter weights into the model weights."""
+    module_mapping = defaultdict(dict)
+    processed_adapter_weight_names = set()
+
+    # map the original tensor names to their adapter counterparts
+    for weight_name in model_weights:
+        end_idx = weight_name.rfind(".weight")
+        key = weight_name[:end_idx]
+        for adapter_weight_name in adapter_weights:
+            if key in adapter_weight_name:
+                # example value: 'base_model.model.model.layers.10.self_attn.v_proj.lora_B.weight'
+                # matrix_type gets the second to last element in the module name, i.e. 'lora_B'
+                matrix_type = adapter_weight_name.split(".")[-2]
+                module_mapping[weight_name][matrix_type] = adapter_weight_name
+                processed_adapter_weight_names.add(adapter_weight_name)
+    
+    # merge adapter weights into model weights
+    merged_weights = {}
+    for weight_name, adapter_weight_names in tqdm(
+        module_mapping.items(), desc="Merging adapter weights", total=len(module_mapping)):
+
+        # TODO: support adapter types beyond LoRA
+        lora_A = adapter_weights[adapter_weight_names["lora_A"]]
+        lora_B = adapter_weights[adapter_weight_names["lora_B"]]
+        delta_weight = compute_delta_weight(
+            lora_A, lora_B, adapter_config.fan_in_fan_out, adapter_config.lora_alpha, adapter_config.r)
+        merged_weights[weight_name] = model_weights[weight_name] + delta_weight
+    return merged_weights, processed_adapter_weight_names
+
+
+def create_merged_weight_files(
+    adapter_id: str, 
+    model_id: str,
+    model_weight_filenames: List[Path]
+) -> List[Path]:
+    """Creates merged weight files for the given adapter ID and filenames."""
+    adapter_filenames = weight_files(adapter_id, extension=".safetensors")
+    
+    adapter_config = LoraConfig.from_pretrained(adapter_id)
+    if adapter_config.base_model_name_or_path != model_id:
+        raise ValueError(f"Adapter {adapter_id} is not compatible with model {model_id}")
+    
+    # load adapter weights from all shards (should have relatively small memory footprint)
+    adapter_weights = {}
+    for filename in adapter_filenames:
+        adapter_weights.update(load_file(filename))
+    remaining_adapter_weight_names = set(adapter_weights.keys())
+
+    merged_weight_directory = f"/data/{adapter_id.replace('/', '--')}-merged/"
+    # just grab the existing files if they already exist and return immediately
+    if os.path.exists(merged_weight_directory):
+        logger.info("Merged weight files already exist, skipping merge computation.")
+        return weight_files(merged_weight_directory)
+
+    os.makedirs(merged_weight_directory)
+    merged_weight_filenames = []
+    for filename in model_weight_filenames:
+        model_weights = load_file(filename)
+        merged_weights, processed_adapter_weight_names = merge_adapter_weights(
+            model_weights, adapter_weights, adapter_config)
+        
+        merged_adapter_filename = Path(merged_weight_directory, os.path.basename(filename))
+        save_file(merged_weights, merged_adapter_filename)
+        logger.debug(f"Saved merged weights into {merged_adapter_filename}")
+
+        merged_weight_filenames.append(merged_adapter_filename)
+        remaining_adapter_weight_names = remaining_adapter_weight_names.difference(
+            processed_adapter_weight_names)
+    
+    if len(remaining_adapter_weight_names) > 0:
+        logger.warning("WARNING: The following lora weights were not merged into the model weights:")
+        for lora_name in remaining_adapter_weight_names:
+            logger.warning("\t" + lora_name)
+
+    return merged_weight_filenames
+
+
+def main():
+    adapter_id = "arnavgrg/codealpaca-qlora"
+    adapter_config = LoraConfig.from_pretrained(adapter_id)
+    model_id = adapter_config.base_model_name_or_path
+    model_weight_filenames = weight_files(model_id, extension=".safetensors")
+    
+    merged_adapter_filenames = create_merged_weight_files(adapter_id, model_id, model_weight_filenames)
+    print(merged_adapter_filenames)
+
+
+if __name__ == '__main__':
+    main()

--- a/server/text_generation_server/utils/weights.py
+++ b/server/text_generation_server/utils/weights.py
@@ -16,6 +16,9 @@ class Weights:
         process_group,
         aliases: Optional[Dict[str, List[str]]] = None,
     ):
+        # idea: maybe we can pass in adapter filenames here and have these take
+        # precedence over the model filenames? If so, then self.routing would
+        # just handle the mapping of tensor names to filenames.
         routing = {}
         for filename in filenames:
             with safe_open(filename, framework="pytorch") as f:


### PR DESCRIPTION
This PR implements loading adapters on server initialization. The work is scoped specifically to:
1. Llama-2 models
2. LoRA adapters
3. Linear adapter layers (specifically, `q_proj` and `v_proj`)

The new code path takes `adapter_id` as a flag. If this flag is a non-empty string, the adapter weights are merged with the original model weights and saved to a `$HUGGINGFACE_HUB_CACHE/model--{adapter_id}-merged/` directory.

After that, we ensure that the `Weights.routing` attribute points to the filepaths of the merged weight tensors if they exist; otherwise, it points to the filepaths of the original weight tensors.

Some tradeoffs with this approach:
- We do not modify any of the original model weights files or adapter weights files. This means we use some additional disk space to store the merged weights files (for Llama-2-7B, about 4.1GB extra disk space is used since these are fully materialized `B@A` weight matrices). I went this direction in case we want to reuse the base model weights at some point (i.e. when we start working on dynamic adapter loading).
- The caller still has to specify `--model-id` in addition to `--adapter-id` when launching the server. This means the caller could shoot themselves in the foot if there is an incompatibility between the two flag values. This would be highly unlikely because the caller should know what model was used to train the adapter of interest. Ideally, we would use `adapter_id` to infer the `model_id`. I went this direction because `model_id` is used in many places, including parts of the code I am less familiar with– I wanted to minimize the unintended consequences of this change. In the future, we can drop the `adapter_id` flag and allow the user to pass in adapter IDs as `model_id` directly.